### PR TITLE
Added a Makefile and a spec file to make RPM with bash-mq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.rpmbuild

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+SHELL := /bin/bash
+NAME=bash-mq
+VERSION=$(shell date +'%Y%m%d%H%M%S')
+RELEASE=$(shell git rev-parse --short HEAD)
+TMPDIR=$(shell pwd)/.rpmbuild
+
+all : clean rpm
+
+clean :
+	rm -f *.rpm
+	rm -rf ${TMPDIR}
+rpm:
+	mkdir -p ${TMPDIR}/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+	sed -e "s/%RELEASE%/${RELEASE}/g" -e "s/%VERSION%/${VERSION}/g" -e "s/%NAME%/${NAME}/g" ${NAME}.spec > ${TMPDIR}/SPECS/${NAME}.spec
+	tar -czf ${TMPDIR}/SOURCES/${NAME}.tar.gz --exclude='.git' --exclude='.rpmbuild' .
+	rpmbuild -vv -bb --define "_topdir ${TMPDIR}" --define "_name ${NAME}" ${TMPDIR}/SPECS/${NAME}.spec
+

--- a/bash-mq.spec
+++ b/bash-mq.spec
@@ -1,0 +1,51 @@
+%define name %{_name}
+%define version %VERSION%
+%define release %RELEASE%
+%define arch noarch
+%define basedir /opt/bash-mq
+
+%define buildroot %{_topdir}/BUILDROOT
+
+
+Name: %{name}
+Version: %{version}	
+Release: %{release}
+Summary: %{name}
+
+Group:		Application/Utils
+License:	DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE V2
+BuildRoot:	%{buildroot}
+Source0:	%{name}.tar.gz
+Requires:	socat
+
+%description
+A bash/awk producer/consumer for activemq or any STOMP compatible MQ
+
+%prep
+tar zxf %{_topdir}/SOURCES/%{name}.tar.gz
+
+	
+%build
+
+
+%install
+mkdir -p %{buildroot}%{basedir}/bin
+
+
+cp stomp-parser.awk %{buildroot}%{basedir}/bin
+cp consume %{buildroot}%{basedir}/bin
+cp produce %{buildroot}%{basedir}/bin
+
+
+%clean
+rm -rf %{buildroot}
+
+
+%files
+%defattr(-,root,root,-)
+%{basedir}/
+
+
+
+%changelog
+


### PR DESCRIPTION
Here's a PR that include a simple Makefile and .spec file to create an RPM with bash-mq.
Depends on socat RPM that is present when you install epel-release.

Tested on CentOS 6.


